### PR TITLE
Allow custom headers in api_client.py

### DIFF
--- a/afc_saaspro_tax/afc_rest_apis/SDK/python/README.md
+++ b/afc_saaspro_tax/afc_rest_apis/SDK/python/README.md
@@ -65,7 +65,7 @@ configuration = avalara.comms.rest.v2.Configuration(
 
 
 # Enter a context with an instance of the API client
-with avalara.comms.rest.v2.ApiClient(configuration) as api_client:
+headers = {	"Authorization": "Basic Zmlyc3QubGFzdEBhdmFsYXJhLmNvbTpzZWNyZXRwYXNzd29yZCE="	"client_id: "56"}with avalara.comms.rest.v2.ApiClient(configuration, headers=headers) as api_client:
     # Create an instance of the API class
     api_instance = avalara.comms.rest.v2.CustomizationApi(api_client)
     requested_client_id = 56 # int | Client id associated with profile(s) to be fetched  Null value will use client id submitting the request or default client id as applicable. (optional)

--- a/afc_saaspro_tax/afc_rest_apis/SDK/python/avalara/comms/rest/v2/api_client.py
+++ b/afc_saaspro_tax/afc_rest_apis/SDK/python/avalara/comms/rest/v2/api_client.py
@@ -65,7 +65,7 @@ class ApiClient(object):
     }
     _pool = None
 
-    def __init__(self, configuration=None, header_name=None, header_value=None,
+    def __init__(self, configuration=None, headers=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
             configuration = Configuration.get_default_copy()
@@ -74,8 +74,8 @@ class ApiClient(object):
 
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {}
-        if header_name is not None:
-            self.default_headers[header_name] = header_value
+        if headers is not None:
+            self.default_headers = headers
         self.cookie = cookie
         # Set default User-Agent.
         self.user_agent = 'OpenAPI-Generator/1.0.0/python'
@@ -115,7 +115,7 @@ class ApiClient(object):
         self.default_headers['User-Agent'] = value
 
     def set_default_header(self, header_name, header_value):
-        self.default_headers[header_name] = header_value
+        self.default_headers = headers
 
     def __call_api(
             self, resource_path, method, path_params=None,

--- a/afc_saaspro_tax/afc_rest_apis/SDK/python/avalara/comms/rest/v2/api_client.py
+++ b/afc_saaspro_tax/afc_rest_apis/SDK/python/avalara/comms/rest/v2/api_client.py
@@ -114,7 +114,7 @@ class ApiClient(object):
     def user_agent(self, value):
         self.default_headers['User-Agent'] = value
 
-    def set_default_header(self, header_name, header_value):
+    def set_default_header(self, headers):
         self.default_headers = headers
 
     def __call_api(


### PR DESCRIPTION
In short this change allows a programmer to create and user their own authentication headers for an API client object since the generated code did not set up authentication properly.